### PR TITLE
fix PHP Fatal error for compatible with ArrayAccess::

### DIFF
--- a/src/Smarty.php
+++ b/src/Smarty.php
@@ -47,7 +47,7 @@ class Smarty implements \ArrayAccess
         $this->smarty->force_compile = $options['force_compile'];
         $this->smarty->debugging = $options['debugging'];
         $this->smarty->compile_check = $options['compile_check'];
-        
+
         $this->smarty->cache_dir = $options['cache_dir'];
         $this->smarty->caching = $options['caching'];
         $this->smarty->cache_lifetime = $options['cache_lifetime'];
@@ -151,8 +151,12 @@ class Smarty implements \ArrayAccess
      *
      * @return mixed The key's value, or the default value
      */
-    public function offsetGet(mixed $key):mixed
+    #[ReturnTypeWillChange]
+    public function offsetGet($key)
     {
+        if (!$this->offsetExists($key)) {
+            return null;
+        }
         return $this->defaultVariables[$key];
     }
 
@@ -162,7 +166,7 @@ class Smarty implements \ArrayAccess
      * @param string $key The data key
      * @param mixed $value The data value
      */
-    public function offsetSet(mixed $key, mixed $value): void
+    public function offsetSet($key, $value): void
     {
         $this->defaultVariables[$key] = $value;
     }
@@ -172,7 +176,7 @@ class Smarty implements \ArrayAccess
      *
      * @param string $key The data key
      */
-    public function offsetUnset(mixed $key): void
+    public function offsetUnset($key): void
     {
         unset($this->defaultVariables[$key]);
     }


### PR DESCRIPTION
synced the code from https://github.com/slimphp/Twig-View/blob/3.x/src/Twig.php
to fix errors like:

```
PHP message: PHP Fatal error:  Declaration of Slim\Views\Smarty::offsetGet(Slim\Views\mixed $key): Slim\Views\mixed must be compatible with ArrayAccess::offsetGet($offset) 
PHP message: PHP Fatal error:  Declaration of Slim\Views\Smarty::offsetSet(Slim\Views\mixed $key, Slim\Views\mixed $value): void must be compatible with ArrayAccess::offsetSet($offset, $value) 
PHP message: PHP Fatal error:  Declaration of Slim\Views\Smarty::offsetUnset(Slim\Views\mixed $key): void must be compatible with ArrayAccess::offsetUnset($offset) 
```